### PR TITLE
Update util.c, make type conversion explicit, fixes `make pedantic` err

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -17,5 +17,5 @@ uint32_t read_uint32_t(uint8_t* buf) {
 }
 
 uint16_t read_uint16_t(uint8_t* buf) {
-  return ((uint32_t)buf[0] << 8) | (uint32_t)buf[1];
+  return (uint16_t)(((uint32_t)buf[0] << 8) | (uint32_t)buf[1]);
 }


### PR DESCRIPTION
I accidentally introduced another implicit conversion which is catched by `make pedantic` #14

The casts for `read_uint16_t` could also be `uint16_t` instead of `uint32_t` since the max bitshift is only 8 but I'll leave that up to you to decide (don't think it will matter).