### PR TITLE
Restore consistency with the header fixes

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1,21 +1,25 @@
-#include <stdio.h>  // for getc, printf
 #include "util.h"
+#include <stdio.h>
 // Endianness helper functions
 
 uint32_t swap_uint32(uint32_t num)
 {
-    return ((num >> 24) & 0xff) | ((num << 8) & 0xff0000) | ((num >> 8) & 0xff00) | ((num << 24) & 0xff000000);
+  return ((num >> 24) & 0xff) | ((num << 8) & 0xff0000) |
+         ((num >> 8) & 0xff00) | ((num << 24) & 0xff000000);
 }
 
 uint32_t swap_uint16(uint16_t num)
 {
-    return ((num >> 8) & 0xff) | ((num << 8) & 0xff00);
+  return ((num >> 8) & 0xff) | ((num << 8) & 0xff00);
 }
 
-uint32_t read_uint32_t(uint8_t* buf) {
-  return ((uint32_t)buf[0] << 24) | ((uint32_t)buf[1] << 16) | ((uint32_t)buf[2] << 8) | (uint32_t)buf[3];
+uint32_t read_uint32(uint8_t *buf)
+{
+  return ((uint32_t)buf[0] << 24) | ((uint32_t)buf[1] << 16) |
+         ((uint32_t)buf[2] << 8) | (uint32_t)buf[3];
 }
 
-uint16_t read_uint16_t(uint8_t* buf) {
-  return ((uint16_t)buf[0] << 8) | (uint32_t)buf[1];
+uint16_t read_uint16(uint8_t *buf)
+{
+  return (uint16_t)((uint16_t)buf[0] << 8) | (uint16_t)buf[1];
 }


### PR DESCRIPTION
1. Function prototypes were changed to no longer include the suffix `_t` in the header but not in the source.

2. Added an additional cast to `(unit16_t)` in `read_uint16` to fix an error when compiling with `make pedantic`.

3. Fixed formatting to not exceed column 80 and keep tabs consistent with other source files.