### PR TITLE
Force usage of LLDB inside of VScode (MIMode)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
             "cwd": "${workspaceFolder}",
             // "stopAtEntry": true,  // uncomment to automatically set breakpoint at start of main.
             "preLaunchTask": "Build ijvm",
+            "MIMode": "lldb",
         },
         {
             "name": "Build and Debug test",
@@ -23,6 +24,7 @@
             // "stopAtEntry": true,  // uncomment to automatically set breakpoint at start of main.
             // "preLaunchTask": "Build all tests",
             "preLaunchTask": "Build test_${input:testID}",
+            "MIMode": "lldb",
         }
     ],
     "inputs": [


### PR DESCRIPTION
This fixes the errors that happen on macOS by specifying explicitly to use `lldb`.

![VScode error on Apple Silicon Mac](https://i.imgur.com/g1wQk1o.png)

I am guessing VScode might actually be using `gdb` by default. So this might also align it with the course manual.

---
This commit forces the usage of lldb, as specificed by the VScode documentation [0]. It should use lldb to begin with, as required by the course manual [1], but it seems to try to use gdb instead.

Note that gdb does not support aarch64, and thus causes an error on Apple Silicon devices. This might also be an issue for Linux users.

[0]: https://code.visualstudio.com/docs/cpp/launch-json-reference#_mimode
[1]: https://vu-oofp.gitlab.io/website/manual/framework.html