### PR TITLE
Add `static` to print_help in main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "ijvm.h"
 #include "util.h"
-void print_help(void)
+static void print_help(void)
 { 
   printf("Usage: ./ijvm binary \n"); 
 }


### PR DESCRIPTION
At the moment `make pedantic` cries about print_help not being used outside of this translation unit and hence should be marked as static.
![image](https://github.com/VU-Programming/copp-skeleton/assets/67706284/14049122-96b0-4c17-9f2b-48af9e913f60)
