### PR TITLE
Added test in task 1 that makes sure the magic number is read correctly

### DIFF
--- a/tests/test1.c
+++ b/tests/test1.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <time.h>
 #include "../include/ijvm.h"
 #include "testutil.h"
 
@@ -65,6 +66,22 @@ void test_constants_2(void)
     destroy_ijvm();
 }
 
+// this test checks that init_ijvm does not return 0 when the magicnum is incorrect
+void test_magicnum(void)
+{
+    srand(time(NULL));
+    byte_t x = rand() % 255;
+    FILE *fp = fopen("files/task1/badfile.ijvm", "wb");
+    int random_num = 5 + rand() % 15;
+    for (int i = 0; i < random_num; i++)
+    {
+        fputc(x, fp);
+        do x = rand() % 255; while (x == 0xEA);
+    }
+    fclose(fp);
+    int res = init_ijvm("files/badfile.ijvm");
+    assert(res != 0);
+}
 
 int main(void)
 {
@@ -73,5 +90,6 @@ int main(void)
     RUN_TEST(test_program_2);
     RUN_TEST(test_constants_1);
     RUN_TEST(test_constants_2);
+    RUN_TEST(test_magicnum);
     return END_TEST();
 }

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -79,7 +79,7 @@ void test_magicnum(void)
         do x = rand() % 255; while (x == 0xEA);
     }
     fclose(fp);
-    int res = init_ijvm("files/badfile.ijvm");
+    int res = init_ijvm("files/task1/badfile.ijvm");
     assert(res != 0);
 }
 


### PR DESCRIPTION
The newly added test `test_magicnum` in task 1 randomly generates a binary file and feeds it into `init_ijvm`. An assertion checks that the result from `init_ijvm != 0`.