### PR TITLE
Fix: change vs-code task for building the tailcall test to match Makefile 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -168,7 +168,7 @@
         {
             "label": "Build test_testbonustail",
             "type": "shell",
-            "command": "make test_testbonustail",
+            "command": "make testbonustail",
             "options": {
                 "cwd": "${workspaceFolder}"
             },


### PR DESCRIPTION
The `Build test_testbonustail` task tried to execute `make test_testbonustail` while the build target is `make testbonustail`