### PR TITLE
Fix: Change vs-code launch options to only set `MIMode` on macOS/OS X systems 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,9 @@
             "cwd": "${workspaceFolder}",
             // "stopAtEntry": true,  // uncomment to automatically set breakpoint at start of main.
             "preLaunchTask": "Build ijvm",
-            "MIMode": "lldb",
+            "osx": {
+                "MIMode": "lldb",
+            },
         },
         {
             "name": "Build and Debug test",
@@ -24,7 +26,9 @@
             // "stopAtEntry": true,  // uncomment to automatically set breakpoint at start of main.
             // "preLaunchTask": "Build all tests",
             "preLaunchTask": "Build test_${input:testID}",
-            "MIMode": "lldb",
+            "osx": {
+                "MIMode": "lldb",
+            },
         }
     ],
     "inputs": [


### PR DESCRIPTION
A previous PR added the `"MIMode": "lldb"` option in the `launch.json` file to set the correct debugger in vs-code on mac. This option, however, breaks the debugger on some Linux systems. This PR modifies the file to only set the option on macOS/OS X systems.