### PR TITLE
Remove: outdated information about compiling with debug prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ Requires make and Clang
 
 Run `make ijvm` to build the ijvm binary
 
-You can enable the debug print (`dprintf`) found in `include/util.h` by
-setting the `-DDEBUG` compiler flag (e.g., `make clean && make testbasic CFLAGS=-DDEBUG`).
-
 # Running a binary
 Run an IJVM program using `./ijvm binary`. For example `./ijvm files/advanced/Tanenbaum.ijvm`.
 


### PR DESCRIPTION
The Readme still mentions compiling with `CFLAGS=-DDEBUG` to enable the `dprintf` statements, however, in the current version of the framework the `dprintf`s are enabled/disabled through setting the `DEBUG_LEVEL` in `util.h` and thereby the `DDEBUG` flag has no effect.