### PR TITLE
fix: fixed conflicting types in util.h and util.c

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -31,8 +31,8 @@ int32_t swap_int32(int32_t num);
 int16_t swap_int16(int16_t num);
 uint32_t read_uint32(uint8_t* buf) ;
 uint16_t read_uint16(uint8_t* buf) ;
-int32_t read_int32(int8_t* buf) ;
-int16_t read_int16(int8_t* buf) ;
+int32_t read_int32(uint8_t* buf) ;
+int16_t read_int16(uint8_t* buf) ;
 
 #if DEBUG_LEVEL >= 1 
 #define dprintf(...) \


### PR DESCRIPTION
In the current framework the functions read_int16 and read_int32 have conflicting definitions in util.h and util.c.
In util.c the functions correctly take a buffer argument of type uint8_t * while the definitions in util.h expect the buffer to be of type int8_t *.