### PR TITLE
Remove __THROW for macos compatibility

### DIFF
--- a/tests/testutil.h
+++ b/tests/testutil.h
@@ -12,7 +12,7 @@
 #include <dlfcn.h>
 
 void *malloc(size_t size);
-void exit(int __status) __THROW __attribute__ ((__noreturn__));
+void exit(int __status) __attribute__ ((__noreturn__));
 
 typedef void (*exit_handle)(int);
 typedef void *(*malloc_handle)(size_t size);


### PR DESCRIPTION
On some (all?) macs __THROW results in the following error
```
tests/testutil.h:15:25: error: expected function body after function declarator
void exit(int __status) __THROW __attribute__ ((__noreturn__));
                        ^
```
From my understanding, this keyword is only used in C++ and in C is just included as a blank placeholder for interoperability. As all the tests seem to be in C, this should not be necessary.
I am not  certain that it might not cause some issues later but it seems to cause no further problems in my limited tests. I also don't know if there might be a more elegant way to work around this issue on macs or what exactly even causes them and I don't have a mac myself to investigate the issue.