### PR TITLE
Update test2.c halt to detect wrong implementation of finished

### DIFF
--- a/tests/test2.c
+++ b/tests/test2.c
@@ -220,7 +220,9 @@ void test_halt(void)
 {
     ijvm* m = init_ijvm_std("files/task2/TestPop1.ijvm");
     assert(m != NULL);
-    run(m);
+    steps(m, 8);
+    assert(!finished(m));
+    step(m);
     assert(finished(m));
     destroy_ijvm(m);
 }


### PR DESCRIPTION
I noticed that one student was passing the HALT tests in test2.c, but in test4.c, they failed the test_wide_check. Not because of an incorrect implementation of WIDE, but an incorrect implementation of finished.

They had a check condition as follows in finished():
`get_instruction(m) == OP_HALT`

The problematic part here is that since finished() is called before executing a step, the HALT step will not actually be executed since finished will result in true. This is only tested in the test_wide_check in test4, and not tested in the halt test of test2. 

Therefore, I propose an update to test_halt, to actually make sure that the HALT step is executed, which ensures that such an incorrect implementation is detected in the halt test of test2 instead of only in the later test_wide_check in test4. This will make sure the student fixes an invalid implementation of finished earlier.