### PR TITLE
Silence assert redefinition warning

### DIFF
--- a/tests/testutil.h
+++ b/tests/testutil.h
@@ -54,6 +54,11 @@ void exit(int __status)
 
 #define RUN_TEST(fun) __run_test(fun, #fun);
 #define END_TEST() __print_test_result(__FILE__);
+
+// temporarily silence clang warnings about assert redefinition
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+
 #define __assert(c) do { \
   if (!(c)) { \
     fprintf(stderr, "Assertion error '%s' in %s:%d\n", #c, __FILE__, __LINE__); \
@@ -63,6 +68,8 @@ void exit(int __status)
 } while (0);
 
 #define assert(c) __assert(c);
+
+#pragma clang diagnostic pop
 
 void steps(ijvm* m, int n);
 


### PR DESCRIPTION
Currently, every test run using `make` (for example: `make testall`) causes two compilation warnings. These occur due to the redefinition of the assert macro. On my machine (Mac M1), these warnings look something like this:

```c
tests/testutil.h:62:9: warning: '__assert' macro redefined [-Wmacro-redefined]
#define __assert(c) do { \
        ^
```
```c
tests/testutil.h:70:9: warning: 'assert' macro redefined [-Wmacro-redefined]
#define assert(c) __assert(c);
        ^
```

Since these warnings do not indicate anything about students' code, I suggest that we silence these so as not to confuse students. This can be done by using the `#pragma` directive, as implemented in this PR.

Here is a short description of each of the `#pragma` directives used in this PR:

- `#pragma clang diagnostic push`:  This directive saves the current state of all diagnostic settings. It's used to create a stack of diagnostic states so that temporary changes can be made to the diagnostic settings and then revert back to the previous state.

- `#pragma clang diagnostic ignored "-Wmacro-redefined"`: This directive tells the Clang compiler to ignore the specific warning identified by -Wmacro-redefined. This is exactly what is triggered by the assert redefinition, so we want to silence this.

- `#pragma clang diagnostic pop`: After the block of code where the redefinition warning is suppressed, this directive restores the previous state of the diagnostic settings that were saved by `#pragma clang diagnostic push`. This ensures that any changes to the diagnostic settings are only **temporary** and do not affect the rest of the code.