### PR TITLE
Git ignore generated test ijvm file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tools
 Computer Programming Project.xcodeproj/xcuserdata/
 Computer Programming Project.xcodeproj/project.xcworkspace/xcuserdata/
 valgrind-*.txt
+files/task1/badfile.ijvm


### PR DESCRIPTION
The `test_magicnum` test in `test1.c` creates an IJVM file with a bad file header to ensure that the magic number is correctly checked. This new IJVM is stored as `files/task1/badfile.ijvm`. Because this file is not being ignored by git, it appears in the staging area - there's no reason to push this randomly generated file so I suggest to simply add it to the `.gitignore`.