### PR TITLE
Remove custom types byte and word

### DIFF
--- a/include/ijvm.h
+++ b/include/ijvm.h
@@ -5,7 +5,6 @@
 #include <stdint.h>  /* contains exact integer types int32_t, uint8_t */
 #include <stdbool.h> /* contains the boolean */
 
-#include "ijvm_types.h"
 #include "ijvm_struct.h"
 
 #define MAGIC_NUMBER 0x1DEADFAD
@@ -79,31 +78,31 @@ void destroy_ijvm(ijvm* m);
 /**
  * Returns the currently loaded program text as a byte array.
  **/
-byte *get_text(ijvm* m);
+uint8_t *get_text(ijvm* m);
 
 
 /**
  * Returns the size of the currently loaded program text.
  **/
-unsigned int get_text_size(ijvm* m);
+uint32_t get_text_size(ijvm* m);
 
 /**
  * @param i index of the constant to obtain
  * @return The constant at location i in the constant pool.
  **/
-word get_constant(ijvm* m, int i);
+int32_t get_constant(ijvm* m, uint32_t i);
 
 
 /**
  * Returns the value of the program counter (as an offset from the first instruction).
  **/
-unsigned int get_program_counter(ijvm* m);
+uint32_t get_program_counter(ijvm* m);
 
 /**
  * This function should return the word at the top of the stack of the current
  * frame, interpreted as a signed integer.
  **/
-word tos(ijvm* m);
+int32_t tos(ijvm* m);
 
 /**
  * Step (perform) one instruction and return.
@@ -130,14 +129,14 @@ bool finished(ijvm* m);
  * @param i index of variable to obtain.
  * @return Returns the i:th local variable of the current frame.
  **/
-word get_local_variable(ijvm* m, int i);
+int32_t get_local_variable(ijvm* m, uint32_t i);
 
 /**
  * @return The value of the current instruction represented as a byte.
  *
  * This should NOT increase the program counter.
  **/
-byte get_instruction(ijvm* m);
+uint8_t get_instruction(ijvm* m);
 
 /**
  * Initializes the IJVM with the binary file found at the provided argument using 
@@ -164,7 +163,7 @@ void run(ijvm* m);
 // Or it can be for example be the number of frames on the stack
 // We use this only to test stack depth when using tailcall is less
 // then when using regular calls. 
-int get_call_stack_size(ijvm* m);
+uint32_t get_call_stack_size(ijvm* m);
 
 
 // Only needed for garbage collection assignment
@@ -173,7 +172,7 @@ int get_call_stack_size(ijvm* m);
 // this method must return true on a reference to that cell
 //  *until* the next NEWARRAY instruction (which may reuse the reference)
 //
-bool is_heap_freed(ijvm* m, word reference);
+bool is_heap_freed(ijvm* m, int32_t reference);
 
 // Only needed for precise garbage collection bonus
 // using ANEWARRAY, AIALOAD and AIASTORE

--- a/include/ijvm_struct.h
+++ b/include/ijvm_struct.h
@@ -4,7 +4,6 @@
 
 #include <stdio.h>  /* contains type FILE * */
 
-#include "ijvm_types.h"
 /**
  * All the state of your IJVM machine goes in this struct!
  **/

--- a/include/ijvm_types.h
+++ b/include/ijvm_types.h
@@ -1,9 +1,0 @@
-#ifndef IJVM_TYPES_H
-#define IJVM_TYPES_H
-
-#include <stdint.h>  /* contains exact integer types int32_t, uint8_t */
-
-typedef uint8_t byte; /* raw memory will be typed as uint8 */
-typedef int32_t word; /* the basic unit of the ijvm will be an int32 */
-
-#endif

--- a/src/ijvm.c
+++ b/src/ijvm.c
@@ -29,31 +29,31 @@ void destroy_ijvm(ijvm* m)
   free(m); // free memory for struct
 }
 
-byte *get_text(ijvm* m) 
+uint8_t *get_text(ijvm* m) 
 {
   // TODO: implement me
   return NULL;
 }
 
-unsigned int get_text_size(ijvm* m) 
+uint32_t get_text_size(ijvm* m) 
 {
   // TODO: implement me
   return 0;
 }
 
-word get_constant(ijvm* m,int i) 
+int32_t get_constant(ijvm* m, uint32_t i) 
 {
   // TODO: implement me
   return 0;
 }
 
-unsigned int get_program_counter(ijvm* m) 
+uint32_t get_program_counter(ijvm* m) 
 {
   // TODO: implement me
   return 0;
 }
 
-word tos(ijvm* m) 
+int32_t tos(ijvm* m) 
 {
   // this operation should NOT pop (remove top element from stack)
   // TODO: implement me
@@ -66,7 +66,7 @@ bool finished(ijvm* m)
   return false;
 }
 
-word get_local_variable(ijvm* m, int i) 
+int32_t get_local_variable(ijvm* m, uint32_t i) 
 {
   // TODO: implement me
   return 0;
@@ -78,7 +78,7 @@ void step(ijvm* m)
 
 }
 
-byte get_instruction(ijvm* m) 
+uint8_t get_instruction(ijvm* m) 
 { 
   return get_text(m)[get_program_counter(m)]; 
 }
@@ -101,7 +101,7 @@ void run(ijvm* m)
 // You can leave these unimplemented if you are not doing these bonus 
 // assignments.
 
-int get_call_stack_size(ijvm* m) 
+uint32_t get_call_stack_size(ijvm* m) 
 {
    // TODO: implement me if doing tail call bonus
    return 0;
@@ -110,7 +110,7 @@ int get_call_stack_size(ijvm* m)
 
 // Checks if reference is a freed heap array. Note that this assumes that 
 // 
-bool is_heap_freed(ijvm* m, word reference) 
+bool is_heap_freed(ijvm* m, int32_t reference) 
 {
    // TODO: implement me if doing garbage collection bonus
    return 0;

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -20,7 +20,7 @@ void test_program_1(void)
     ijvm* m = init_ijvm_std("files/task1/program1.ijvm");
     assert(m != NULL);
     assert(get_text_size(m) == 7);
-    byte *ip = get_text(m);
+    uint8_t *ip = get_text(m);
 
     // If it fails here you haven't implemented get_text()
     assert(ip != NULL);
@@ -28,7 +28,7 @@ void test_program_1(void)
     assert(ip[0] == 0x10); // BIPUSH
     assert(ip[2] == 0x10); // BIPUSH
     assert(ip[4] == 0x60); // IADD
-    assert(ip[5] == (byte)0xFD); // OUT
+    assert(ip[5] == (uint8_t)0xFD); // OUT
     destroy_ijvm(m);
 }
 
@@ -37,18 +37,18 @@ void test_program_2(void)
     ijvm* m = init_ijvm_std("files/task1/program2.ijvm");
     assert(m != NULL);
     assert(get_text_size(m) == 16);
-    byte *ip = get_text(m);
+    uint8_t *ip = get_text(m);
 
     // Instructions in binary
     assert(ip[0] == 0x00);
-    assert(ip[1] == (byte)0x13);
-    assert(ip[4] == (byte)0x59);
-    assert(ip[5] == (byte)0x13);
-    assert(ip[8] == (byte)0x60);
-    assert(ip[9] == (byte)0x13);
-    assert(ip[12] == (byte)0x60);
-    assert(ip[13] == (byte)0xFD);
-    assert(ip[14] == (byte)0x00);
+    assert(ip[1] == (uint8_t)0x13);
+    assert(ip[4] == (uint8_t)0x59);
+    assert(ip[5] == (uint8_t)0x13);
+    assert(ip[8] == (uint8_t)0x60);
+    assert(ip[9] == (uint8_t)0x13);
+    assert(ip[12] == (uint8_t)0x60);
+    assert(ip[13] == (uint8_t)0xFD);
+    assert(ip[14] == (uint8_t)0x00);
     destroy_ijvm(m);
 }
 
@@ -89,7 +89,7 @@ void test_magicnum_swap(void)
 void test_magicnum(void)
 {
     srand((unsigned int)time(NULL));
-    byte x = rand() % 255;
+    uint8_t x = rand() % 255;
     FILE *fp = fopen("files/task1/badfile.ijvm", "wb");
     int random_num = 5 + rand() % 15;
     for (int i = 0; i < random_num; i++)


### PR DESCRIPTION
Currently, the framework uses the custom typedefs `word` and `byte`, which are defined as follows:

```c
typedef uint8_t byte; /* raw memory will be typed as uint8 */
typedef int32_t word; /* the basic unit of the ijvm will be an int32 */
```

Students who heavily rely on using these typedefs demonstrate a lack of understanding of types in general, in relation to the number of bits that each type uses as well as its signedness. This leads to many bugs in their program that are hard to reason about without a solid understanding of appropriate type usage. Additionally, the abstraction of `byte` and `word` dilutes the meaning of bytes and words, as both of these do not have a clear standard for the signedness they represent but only refer to the number of bits present.

This PR removes these typedefinitions from the framework as well as all of its references. By introducing more explicit types like `int32_t` in the framework, students will hopefully gain a better grasp of the importance of types and their appropriate usage.